### PR TITLE
Fix child theme css loading

### DIFF
--- a/inc/classes/Style.php
+++ b/inc/classes/Style.php
@@ -227,7 +227,7 @@ class Style {
 	public function child_theme_styles() {
 		if ( is_child_theme() && apply_filters( 'gridd_load_child_theme_styles', true ) ) {
 			// Note to code reviewers: wp_strip_all_tags here is sufficient escape to ensure everything is interpreted as CSS.
-			echo '<style>' . wp_strip_all_tags( Theme::get_fcontents( get_stylesheet_directory() . '/style.css' ), true ) . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '<style>' . wp_strip_all_tags( Theme::get_fcontents( get_stylesheet_directory() . '/style.css', true ), true ) . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 }

--- a/inc/classes/Style.php
+++ b/inc/classes/Style.php
@@ -225,7 +225,8 @@ class Style {
 	 * @return void
 	 */
 	public function child_theme_styles() {
-		if ( is_child_theme() && apply_filters( 'gridd_load_child_theme_styles', true ) ) {
+		error_log( $this->context );
+		if ( is_child_theme() && apply_filters( 'gridd_load_child_theme_styles', true ) && 'grid-part/content' === $this->context ) {
 			// Note to code reviewers: wp_strip_all_tags here is sufficient escape to ensure everything is interpreted as CSS.
 			echo '<style>' . wp_strip_all_tags( Theme::get_fcontents( get_stylesheet_directory() . '/style.css', true ), true ) . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}

--- a/inc/classes/Style.php
+++ b/inc/classes/Style.php
@@ -225,7 +225,6 @@ class Style {
 	 * @return void
 	 */
 	public function child_theme_styles() {
-		error_log( $this->context );
 		if ( is_child_theme() && apply_filters( 'gridd_load_child_theme_styles', true ) && 'grid-part/content' === $this->context ) {
 			// Note to code reviewers: wp_strip_all_tags here is sufficient escape to ensure everything is interpreted as CSS.
 			echo '<style>' . wp_strip_all_tags( Theme::get_fcontents( get_stylesheet_directory() . '/style.css', true ), true ) . '</style>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
binds the child style.css to content part so it loads only 1 time.

passes `true` to get_fcontents due to abspath.